### PR TITLE
fix: let a re-registered matcher override its calledWith config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,8 @@ users.getName.calledWith(1).mockReturnValue('Ada');
 users.getName.mustBeCalledWith(1).mockReturnValue('Ada');
 // asymmetric matchers work in both
 users.save.calledWith(expect.objectContaining({ id: 1 })).mockReturnValue(true);
+// re-registering the same arguments replaces the answer — matcher arguments included
+users.save.calledWith(expect.objectContaining({ id: 1 })).mockReturnValue(false);
 
 // promises
 users.load.resolveWith({ id: 1 });
@@ -373,6 +375,13 @@ const [first$, second$] = feed.watch$.nextWithPerCall([{ value: 'a' }, { value: 
 feed.items$.throwWith('FAKE ERROR');
 const subject = feed.items$.returnSubject(); // ReplaySubject, for anything the helpers miss
 ```
+
+An exact argument list is matched before the asymmetric configs, and those are tried in
+registration order — a narrow config written first keeps its calls. Two matchers count as the same
+argument when they accept the same values (same matcher class, sample and inversion), which is what
+makes a second `calledWith(1, expect.anything())` an override rather than a second config sitting
+behind the first. A hand-rolled `{ asymmetricMatch }` object is compared by identity instead: its
+verdict is a closure, so only re-registering that same instance overrides.
 
 `mock.settledResults` is native on Vitest and polyfilled on Bun / `node:test`, so it is identical on
 all three. Entries are `{ type: 'fulfilled' | 'incomplete' | 'rejected', value }`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,29 @@ The latest released version here must always match the one published on
 
 ### Fixed
 
+- **A `calledWith` config holding an asymmetric matcher could not be overridden ([#6](https://github.com/ASDAlexey/vitest-auto-spy/issues/6)).**
+  `spy.load.calledWith(12, expect.anything()).mockReturnValue('a')` followed by the same line
+  returning `'b'` kept answering `'a'`. Exact argument lists are keyed in a map, where the second
+  registration simply overwrites the first; a config containing a matcher cannot be a static key, so
+  it lives in a list that lookup scans front to back — and `expect.anything()` builds a fresh
+  instance per call, so the second config was appended *behind* one that still matched every call it
+  was meant to take over. It never answered, and a `beforeEach` reconfiguring the same spy grew the
+  list once per test. Re-registering an equivalent argument list now replaces the config in place,
+  which also keeps the registration order that decides between two *overlapping* configs — a narrow
+  `expect.any(Number)` written before a wide `expect.anything()` still wins. Two matchers count as
+  equivalent when they accept the same values: same matcher class, same own state (`sample`,
+  `inverse`, `precision`), both carrying the runner's `Symbol.for('jest.asymmetricMatcher')` brand.
+  A hand-rolled `{ asymmetricMatch }` object carries no brand and its verdict is a closure that no
+  serialization can compare, so those are still compared by reference and only the same instance
+  overrides. Affects every helper on the chain — `mockReturnValue`, `resolveWith`, `nextWith`,
+  `nextOneTimeWith`, the per-call variants — and `mustBeCalledWith` alike.
+
+- **A `RegExp` argument keyed as `{}`.** A regular expression has no own enumerable entries, so the
+  argument serializer rendered every one of them identically: `calledWith(/a/)` answered a call made
+  with `/b/`, and a `mustBeCalledWith` mismatch printed `{}` on both sides. It now renders as its
+  literal (`/ab+/giu`). This is also what tells `expect.stringMatching('a')` apart from
+  `expect.stringContaining('a')` when deciding whether a re-registration is an override.
+
 - **`using` on Node 22: the package installs the missing `Symbol.dispose` itself.** Node 22 ships V8
   12.4, which has no explicit resource management, so Node supplies `Symbol.dispose` in JavaScript —
   as `Symbol.for('nodejs.dispose')`, and **onto its main realm only**. Vitest's `jsdom` /

--- a/README.md
+++ b/README.md
@@ -1231,6 +1231,24 @@ Wanted: getName(1)
 Actual: getName(2)
 ```
 
+### Matching order, and re-configuring the same arguments
+
+An exact argument list is matched first; the asymmetric configs (`expect.any(Number)`,
+`expect.objectContaining({ … })`, …) are then tried in the order they were registered, so a narrow
+config placed before a wide one keeps its calls. Registering the **same** argument list again
+replaces the answer it gave before — matcher arguments included:
+
+```ts
+myService.getName.calledWith(expect.anything()).mockReturnValue('first');
+myService.getName.calledWith(expect.anything()).mockReturnValue('second');
+expect(myService.getName(1)).toBe('second');
+```
+
+Each `expect.anything()` is a new object, so the two are compared by what they accept rather than by
+identity — same matcher class, same sample, same inversion. A hand-rolled `{ asymmetricMatch }`
+object is the exception: its verdict lives in a closure nothing can read, so two of them are always
+two configs and only the very same instance, re-registered, overrides.
+
 ## Promise-returning methods
 
 ```ts

--- a/changes/unreleased.md
+++ b/changes/unreleased.md
@@ -43,6 +43,15 @@ _Last released: **v3.11.0** (2026-08-30) — the git tag and `package.json` agre
   matching either member: `read(1)`, `read('ok', 'extra')` and `read()` all compiled on a double of
   `read(key: string)`. Now `MockInstance`, which carries the same helpers without a call signature.
   Tightens existing suites; `expectTypeOf(spy.m).parameters` resolves as a bonus.
+- **Fixed — a `calledWith` config with an asymmetric matcher could not be overridden** (issue #6).
+  A second `calledWith(12, expect.anything())` was appended behind the first, which still matched,
+  so the earlier value kept being returned; a `beforeEach` reconfiguring the same spy also grew the
+  matcher list once per test. An equivalent argument list now replaces the config in place, keeping
+  the order that decides between overlapping configs. Matchers count as equivalent when they accept
+  the same values (same class, same own state, runner-branded); hand-rolled `{ asymmetricMatch }`
+  objects stay reference-compared.
+- **Fixed — a `RegExp` argument serialized as `{}`**, so `calledWith(/a/)` answered a call made with
+  `/b/`. It renders as its literal now.
 - **Fixed — `nextWithValues` dropped a falsy value.** `{ value: false }`, `{ value: 0 }`, `{ value: '' }`
   and a falsy `{ errorValue }` emitted nothing: a truthiness check sat on top of a presence guard.
 - **Fixed — `createWithAutoSpies(...).spies.get(token)` minted a spy for a token nobody injected**,

--- a/docs-site/core/control-helpers.md
+++ b/docs-site/core/control-helpers.md
@@ -70,6 +70,24 @@ myService.save.calledWith(expect.objectContaining({ id: 1 })).mockReturnValue(tr
 expect(myService.save({ id: 1, name: 'x' })).toBe(true);
 ```
 
+An exact argument list is matched before any of them, and the matcher configs are tried in the
+order they were registered — a narrow config written before a wide one keeps its calls.
+
+Registering the **same** argument list again replaces the answer it gave before, exactly as it does
+for exact arguments:
+
+```ts
+myService.getName.calledWith(expect.anything()).mockReturnValue('first');
+myService.getName.calledWith(expect.anything()).mockReturnValue('second');
+expect(myService.getName(1)).toBe('second');
+```
+
+Each `expect.anything()` call builds a new object, so "the same argument" cannot mean the same
+instance: two matchers are the same when they accept the same values — same matcher class, same
+sample, same inversion. A hand-rolled `{ asymmetricMatch }` object is the exception. Its verdict
+lives in a closure that no comparison can read, so two of them are always two configs, and only
+that very instance, registered again, overrides.
+
 ## Promise-returning methods — `resolveWith`
 
 ```ts

--- a/docs-site/public/llms-full.txt
+++ b/docs-site/public/llms-full.txt
@@ -925,6 +925,24 @@ myService.save.calledWith(expect.objectContaining({ id: 1 })).mockReturnValue(tr
 expect(myService.save({ id: 1, name: 'x' })).toBe(true);
 ```
 
+An exact argument list is matched before any of them, and the matcher configs are tried in the
+order they were registered — a narrow config written before a wide one keeps its calls.
+
+Registering the **same** argument list again replaces the answer it gave before, exactly as it does
+for exact arguments:
+
+```ts
+myService.getName.calledWith(expect.anything()).mockReturnValue('first');
+myService.getName.calledWith(expect.anything()).mockReturnValue('second');
+expect(myService.getName(1)).toBe('second');
+```
+
+Each `expect.anything()` call builds a new object, so "the same argument" cannot mean the same
+instance: two matchers are the same when they accept the same values — same matcher class, same
+sample, same inversion. A hand-rolled `{ asymmetricMatch }` object is the exception. Its verdict
+lives in a closure that no comparison can read, so two of them are always two configs, and only
+that very instance, registered again, overrides.
+
 ## Promise-returning methods — `resolveWith`
 
 ```ts
@@ -2936,9 +2954,18 @@ behaviour, and it is worth knowing which is which.
 | `spyOn(obj, 'prop', 'get')`   | supported                    | throws — accessors are not supported yet                | accessor spies go through property redefinition     |
 | Spy names in failure messages | `vi.fn()` names              | `mockName()`                                            | set for you                                         |
 | Fake timers                   | `vi.useFakeTimers()`         | `jest.useFakeTimers()`                                  | not normalised — `vitest-auto-spy/setup` is Vitest-only |
+| `expect.any(...)` inside `calledWith` | matched as a predicate | never matches — see below                              | not normalised — use exact arguments on Bun         |
 
 `mock.settledResults` is documented under
 [Control helpers → Inspecting promise outcomes](https://asdalexey.github.io/vitest-auto-spy/core/control-helpers#settled-results).
+
+The matcher row is the one worth reading twice, because it fails quietly. Vitest's asymmetric
+matchers are JavaScript objects carrying an `asymmetricMatch` method, which is what
+[`calledWith`](https://asdalexey.github.io/vitest-auto-spy/core/control-helpers#asymmetric-matchers-in-calledwith) evaluates against the actual
+arguments. Bun's are native objects that expose no such method and no readable state, so a config
+holding one is stored as an ordinary argument and matches nothing — `read.calledWith(expect.any(Number))`
+answers `undefined` for `read(7)` rather than throwing. On Bun, dispatch on exact arguments, or use
+`mockImplementation` when the answer really does depend on the shape of an argument.
 
 ## Bun 1.4 test-runner flags
 

--- a/docs-site/runtimes/bun.md
+++ b/docs-site/runtimes/bun.md
@@ -68,9 +68,18 @@ behaviour, and it is worth knowing which is which.
 | `spyOn(obj, 'prop', 'get')`   | supported                    | throws — accessors are not supported yet                | accessor spies go through property redefinition     |
 | Spy names in failure messages | `vi.fn()` names              | `mockName()`                                            | set for you                                         |
 | Fake timers                   | `vi.useFakeTimers()`         | `jest.useFakeTimers()`                                  | not normalised — `vitest-auto-spy/setup` is Vitest-only |
+| `expect.any(...)` inside `calledWith` | matched as a predicate | never matches — see below                              | not normalised — use exact arguments on Bun         |
 
 `mock.settledResults` is documented under
 [Control helpers → Inspecting promise outcomes](/core/control-helpers#settled-results).
+
+The matcher row is the one worth reading twice, because it fails quietly. Vitest's asymmetric
+matchers are JavaScript objects carrying an `asymmetricMatch` method, which is what
+[`calledWith`](/core/control-helpers#asymmetric-matchers-in-calledwith) evaluates against the actual
+arguments. Bun's are native objects that expose no such method and no readable state, so a config
+holding one is stored as an ordinary argument and matches nothing — `read.calledWith(expect.any(Number))`
+answers `undefined` for `read(7)` rather than throwing. On Bun, dispatch on exact arguments, or use
+`mockImplementation` when the answer really does depend on the shape of an argument.
 
 ## Bun 1.4 test-runner flags
 

--- a/skills/vitest-auto-spy/SKILL.md
+++ b/skills/vitest-auto-spy/SKILL.md
@@ -209,6 +209,14 @@ it('loads', async () => {
 - **Never assert a resource with `expect(r.value()).toEqual(...)` alone** — an unresolved resource
   still holds its _default_, so that passes while proving nothing. `toHaveResourceValue(v)` after
   `registerResourceMatchers()` fails unless the resource actually resolved.
+- **`calledWith` matches exact arguments first, then the matcher configs in registration order** —
+  so put the narrow `expect.any(Number)` before the wide `expect.anything()` when both can match.
+  Re-registering the same arguments replaces the previous answer, matcher arguments included: two
+  `calledWith(1, expect.anything())` lines are an override, not two configs.
+- **On Bun (`bun:test`), an asymmetric matcher inside `calledWith` matches nothing** — Bun's
+  `expect.any()` / `expect.objectContaining()` are native objects carrying no `asymmetricMatch`, so
+  the config is kept as an ordinary argument and the call falls through to `undefined` instead of
+  failing. Dispatch on exact arguments there, or use `mockImplementation`.
 - **Never put `captureArg()` in `calledWith`** — it matches every value, so it configures a return
   for every call. It belongs in `toHaveBeenCalledWith`; the types enforce this.
 - **Never `vi.mock('@angular/core')`** (or any relative path) under the Angular unit-test builder —

--- a/src/auto-spy.spec.ts
+++ b/src/auto-spy.spec.ts
@@ -288,6 +288,57 @@ describe('createSpyFromClass', () => {
     expect(spy.syncMethod('x' as unknown as number)).toBeUndefined();
   });
 
+  // The reproduction from issue #6, as it was reported. Both halves are here on purpose: the
+  // exact-argument one always worked — it overwrites a key in a map — and it is the control that
+  // says the matcher half is failing on the matcher and not on `calledWith` as such.
+  it('overrides calledWith for exact arguments and for matcher arguments alike (issue #6)', () => {
+    class Reported {
+      test(_param: number, _c: { y: number }): string {
+        throw new Error('Not implemented');
+      }
+    }
+
+    const exact = createSpyFromClass(Reported);
+
+    exact.test.calledWith(12, { y: 3 }).mockReturnValue('success');
+    expect(exact.test(12, { y: 3 })).toEqual('success');
+
+    exact.test.calledWith(12, { y: 3 }).mockReturnValue('failure');
+    expect(exact.test(12, { y: 3 })).toEqual('failure');
+
+    const matched = createSpyFromClass(Reported);
+
+    matched.test.calledWith(12, expect.anything()).mockReturnValue('success');
+    expect(matched.test(12, { y: 3 })).toEqual('success');
+
+    // This is the assertion the issue opened on: it returned 'success' before the fix.
+    matched.test.calledWith(12, expect.anything()).mockReturnValue('failure');
+    expect(matched.test(12, { y: 3 })).toEqual('failure');
+  });
+
+  // Regression (issue #6): `expect.anything()` builds a fresh matcher instance per call, so the
+  // second config used to be appended behind the first — which still matched — and never answered.
+  it('calledWith with an equivalent matcher overrides the earlier config', () => {
+    const spy = createSpyFromClass(MyService);
+
+    spy.syncMethod.calledWith(expect.anything()).mockReturnValue('first');
+    expect(spy.syncMethod(7)).toBe('first');
+
+    spy.syncMethod.calledWith(expect.anything()).mockReturnValue('second');
+    expect(spy.syncMethod(7)).toBe('second');
+
+    // A different matcher stays a separate config — and the narrower one, registered first, still
+    // takes precedence over the wider one, because the override replaced it in place.
+    const narrow = createSpyFromClass(MyService);
+
+    narrow.syncMethod.calledWith(expect.any(Number)).mockReturnValue('number');
+    narrow.syncMethod.calledWith(expect.anything()).mockReturnValue('anything');
+    narrow.syncMethod.calledWith(expect.any(Number)).mockReturnValue('number again');
+
+    expect(narrow.syncMethod(7)).toBe('number again');
+    expect(narrow.syncMethod('x' as unknown as number)).toBe('anything');
+  });
+
   it('falls back to the type-driven proxy when the prototype names nothing', () => {
     // An abstract class is the case that matters: `abstract read()` is erased, so the chain ends
     // with an empty method set and the assembled `{}` would fail on the first call in production
@@ -607,6 +658,20 @@ describe('observable methods', () => {
     const b = await collect(spy.getObs(5));
     expect(a.values).toEqual([1]);
     expect(b.values).toEqual([2]);
+  });
+
+  // Regression (issue #6): the same override, on the observable and promise chains.
+  it('calledWith().nextWith and .resolveWith are overridden through an equivalent matcher', async () => {
+    spy.getObs.calledWith(expect.any(Number)).nextWith(1);
+    spy.getObs.calledWith(expect.any(Number)).nextWith(2);
+
+    const emitted = await collect(spy.getObs(5).pipe(take(1)));
+    expect(emitted.values).toEqual([2]);
+
+    spy.getPromise.calledWith(expect.any(Number)).resolveWith('first');
+    spy.getPromise.calledWith(expect.any(Number)).resolveWith('second');
+
+    await expect(spy.getPromise(5)).resolves.toBe('second');
   });
 
   // Regression (bug #1): a delayed per-call OBSERVABLE value must not be treated

--- a/src/lib/args-map.spec.ts
+++ b/src/lib/args-map.spec.ts
@@ -101,6 +101,114 @@ describe('ArgsMap', () => {
     expect(map.get([6])).toBe('any');
   });
 
+  it('overrides an asymmetric config registered with an equivalent matcher', () => {
+    // `expect.anything()` is a fresh instance per call, so a re-registration used to be appended
+    // behind the config it was meant to replace and never reached. See issue #6.
+    const map = new ArgsMap();
+    map.set([12, expect.anything()], 'first');
+    map.set([12, expect.anything()], 'second');
+
+    expect(map.get([12, { y: 3 }])).toBe('second');
+    expect(map.configured()).toEqual(['[12,Anything]']);
+  });
+
+  it('overrides a matcher config whose sample matches, and keeps one whose sample differs', () => {
+    const map = new ArgsMap();
+    map.set([expect.objectContaining({ id: 1 })], 'one');
+    map.set([expect.objectContaining({ id: 2 })], 'two');
+    map.set([expect.objectContaining({ id: 1 })], 'one again');
+
+    expect(map.get([{ id: 1 }])).toBe('one again');
+    expect(map.get([{ id: 2 }])).toBe('two');
+  });
+
+  it('keeps matchers of different classes apart even when their state is alike', () => {
+    // Both hold the sample `'a'` and neither is inverted: only the class tells them apart.
+    const map = new ArgsMap();
+    map.set([expect.stringContaining('a')], 'containing');
+    map.set([expect.stringMatching('a')], 'matching');
+
+    expect(map.configured()).toHaveLength(2);
+    expect(map.get(['a'])).toBe('containing');
+  });
+
+  it('keeps a matcher and its inverse apart', () => {
+    const map = new ArgsMap();
+    map.set([expect.objectContaining({ id: 1 })], 'containing');
+    map.set([expect.not.objectContaining({ id: 1 })], 'not containing');
+
+    expect(map.get([{ id: 1 }])).toBe('containing');
+    expect(map.get([{ id: 2 }])).toBe('not containing');
+  });
+
+  it('overrides only when the literal args around the matcher match too', () => {
+    const map = new ArgsMap();
+    map.set([1, expect.any(Number)], 'one');
+    map.set([2, expect.any(Number)], 'two');
+    map.set([1, expect.any(Number)], 'one again');
+    map.set([1, expect.any(String)], 'one string');
+
+    expect(map.get([1, 5])).toBe('one again');
+    expect(map.get([2, 5])).toBe('two');
+    expect(map.get([1, 'x'])).toBe('one string');
+  });
+
+  it('does not treat a matcher position and a literal position as the same config', () => {
+    const map = new ArgsMap();
+    map.set([expect.any(Number), 'go'], 'matcher first');
+    map.set(['go', expect.any(Number)], 'literal first');
+
+    expect(map.get([5, 'go'])).toBe('matcher first');
+    expect(map.get(['go', 5])).toBe('literal first');
+  });
+
+  it('does not override across a differing arity', () => {
+    const map = new ArgsMap();
+    map.set([expect.any(Number)], 'one arg');
+    map.set([expect.any(Number), 'extra'], 'two args');
+
+    expect(map.get([5])).toBe('one arg');
+    expect(map.get([5, 'extra'])).toBe('two args');
+  });
+
+  it('compares a hand-rolled matcher by reference only', () => {
+    // A duck-typed matcher carries no runner brand: its verdict lives in a closure that no
+    // serialization can see, so two of them are never assumed to be the same expectation.
+    const positive = { asymmetricMatch: (value: unknown): boolean => typeof value === 'number' && value > 0 };
+    const negative = { asymmetricMatch: (value: unknown): boolean => typeof value === 'number' && value < 0 };
+
+    const map = new ArgsMap();
+    map.set([positive], 'positive');
+    map.set([negative], 'negative');
+
+    expect(map.get([1])).toBe('positive');
+    expect(map.get([-1])).toBe('negative');
+
+    // The same instance re-registered is the same config, and does override.
+    map.set([positive], 'positive again');
+
+    expect(map.get([1])).toBe('positive again');
+    expect(map.configured()).toHaveLength(2);
+  });
+
+  it('describes a hand-rolled matcher by its class when it cannot describe itself', () => {
+    const map = new ArgsMap();
+    map.set([{ asymmetricMatch: (): boolean => true }], 'any');
+
+    expect(map.configured()).toEqual(['[[object Object]]']);
+  });
+
+  it('keeps the registration order that decides between overlapping configs', () => {
+    const map = new ArgsMap();
+    map.set([expect.any(Number)], 'number');
+    map.set([expect.anything()], 'anything');
+    // Replacing in place, rather than appending, leaves the narrower config in front.
+    map.set([expect.any(Number)], 'number again');
+
+    expect(map.get([5])).toBe('number again');
+    expect(map.get(['x'])).toBe('anything');
+  });
+
   it('serializes a config arg once at set() time, not on every lookup', () => {
     // The config arg never changes after it is registered, so re-rendering it per call was pure
     // waste — an asymmetric config whose other arg is a large object paid two deep walks per

--- a/src/lib/args-map.ts
+++ b/src/lib/args-map.ts
@@ -24,6 +24,11 @@ interface AsymmetricMatcher {
    * `asymmetricMatch`; there the class name (`String(matcher)`) is the best available description.
    */
   toAsymmetricMatcher?: () => string;
+  /**
+   * The brand the runner stamps on its own matcher instances — see {@link ASYMMETRIC_MATCHER_BRAND}.
+   * Optional because a hand-rolled matcher carries none, which is exactly what the check is for.
+   */
+  $$typeof?: unknown;
 }
 
 /**
@@ -57,6 +62,47 @@ function hasAsymmetricMatcher(args: unknown[]): boolean {
   return args.some(isAsymmetricMatcher);
 }
 
+/**
+ * The brand every Vitest/Jest asymmetric matcher instance carries. It is what makes a matcher's own
+ * state a faithful description of it: such an instance is one of the runner's matcher classes, and
+ * everything that decides its verdict — `sample`, `inverse`, `precision` — lives in enumerable own
+ * fields. A hand-rolled `{ asymmetricMatch }` object carries no brand and no such guarantee: two of
+ * them holding different closures serialize identically, so they are only ever compared by
+ * reference.
+ */
+const ASYMMETRIC_MATCHER_BRAND = Symbol.for('jest.asymmetricMatcher');
+
+/**
+ * Whether two config args denote the same expectation, so that registering the second overrides the
+ * first rather than being shadowed by it.
+ *
+ * `expect.anything()` builds a fresh instance per call, so reference equality alone would make
+ * `calledWith(1, expect.anything())` unoverridable. Two branded matchers of the same class whose
+ * own state serializes alike are interchangeable — they accept exactly the same values — and the
+ * class has to be compared as well as the state, because `expect.stringContaining('a')` and
+ * `expect.stringMatching('a')` differ in behaviour and not in fields.
+ */
+function isSameMatcher(configArg: AsymmetricMatcher, candidateArg: unknown): boolean {
+  if (configArg === candidateArg) {
+    return true;
+  }
+
+  if (!isAsymmetricMatcher(candidateArg) || !isBrandedMatcher(configArg) || !isBrandedMatcher(candidateArg)) {
+    return false;
+  }
+
+  if (Object.getPrototypeOf(configArg) !== Object.getPrototypeOf(candidateArg)) {
+    return false;
+  }
+
+  return serializeValue(configArg) === serializeValue(candidateArg);
+}
+
+/** Whether a matcher is one the runner built, and so describes itself through its own fields. */
+function isBrandedMatcher(matcher: AsymmetricMatcher): boolean {
+  return matcher.$$typeof === ASYMMETRIC_MATCHER_BRAND;
+}
+
 export class ArgsMap {
   // Prototype-less so a `'__proto__'` (or `'constructor'`) serialized key is a
   // plain own property, never walking or polluting the object prototype chain.
@@ -72,24 +118,7 @@ export class ArgsMap {
 
   set(key: unknown, value: unknown): void {
     if (Array.isArray(key) && hasAsymmetricMatcher(key)) {
-      const serialized: (string | undefined)[] = [];
-      const described: string[] = [];
-
-      for (const arg of key) {
-        if (isAsymmetricMatcher(arg)) {
-          serialized.push(undefined);
-          described.push(arg.toAsymmetricMatcher?.() ?? String(arg));
-        } else {
-          const rendered = this.#serialize([arg]);
-
-          serialized.push(rendered);
-          // `#serialize` brackets the single-element array it is given; the bare rendering is what
-          // goes between the commas of the failure message.
-          described.push(rendered.slice(1, -1));
-        }
-      }
-
-      this.#matcherConfigs.push({ args: key, serialized, described, value });
+      this.#setMatcherConfig(this.#buildMatcherConfig(key, value));
 
       return;
     }
@@ -127,6 +156,63 @@ export class ArgsMap {
     const asymmetric = this.#matcherConfigs.map((config) => `[${config.described.join(',')}]`);
 
     return [...Object.keys(this.#map), ...asymmetric];
+  }
+
+  /** Render one asymmetric config once, at registration time. See {@link MatcherConfig}. */
+  #buildMatcherConfig(key: unknown[], value: unknown): MatcherConfig {
+    const serialized: (string | undefined)[] = [];
+    const described: string[] = [];
+
+    for (const arg of key) {
+      if (isAsymmetricMatcher(arg)) {
+        serialized.push(undefined);
+        described.push(arg.toAsymmetricMatcher?.() ?? String(arg));
+      } else {
+        const rendered = this.#serialize([arg]);
+
+        serialized.push(rendered);
+        // `#serialize` brackets the single-element array it is given; the bare rendering is what
+        // goes between the commas of the failure message.
+        described.push(rendered.slice(1, -1));
+      }
+    }
+
+    return { args: key, serialized, described, value };
+  }
+
+  /**
+   * Register an asymmetric config, replacing an equivalent one in place.
+   *
+   * Re-registering args is how a test overrides an earlier answer, and on the exact map that falls
+   * out for free — the second `set` writes the same key. The matcher list has to do it by hand:
+   * lookup takes the first predicate that matches, so an appended duplicate would sit behind the
+   * config it was meant to replace and never be reached, and a `beforeEach` that reconfigures the
+   * same spy would grow the list on every test. Replacing in place also keeps the registration
+   * order that decides which of two *overlapping* configs wins.
+   */
+  #setMatcherConfig(config: MatcherConfig): void {
+    const index = this.#matcherConfigs.findIndex((existing) => this.#sameConfigArgs(existing, config));
+
+    if (index === -1) {
+      this.#matcherConfigs.push(config);
+
+      return;
+    }
+
+    this.#matcherConfigs[index] = config;
+  }
+
+  /** Whether two configs were registered for the same argument list, matcher positions included. */
+  #sameConfigArgs(existing: MatcherConfig, candidate: MatcherConfig): boolean {
+    if (existing.args.length !== candidate.args.length) {
+      return false;
+    }
+
+    // A matcher position and a literal one never compare equal: a literal's serialization is a
+    // string where a matcher's is `undefined`, and `isSameMatcher` rejects a non-matcher outright.
+    return existing.args.every((arg, index) =>
+      isAsymmetricMatcher(arg) ? isSameMatcher(arg, candidate.args[index]) : existing.serialized[index] === candidate.serialized[index],
+    );
   }
 
   // Keys are always argument arrays; `serializeValue` renders them to a stable,

--- a/src/lib/serialize-args.spec.ts
+++ b/src/lib/serialize-args.spec.ts
@@ -30,6 +30,13 @@ describe('serializeValue', () => {
     expect(serializeValue(new Date(0))).toBe('new Date(0)');
   });
 
+  it('renders RegExp by its source and flags (no `{}` collision)', () => {
+    expect(serializeValue(/ab+/giu)).toBe('/ab+/giu');
+    // A regular expression has no own enumerable entries; without its own branch every one of them
+    // keys as `{}` and `calledWith(/a/)` answers a call made with `/b/`.
+    expect(serializeValue(/a/)).not.toBe(serializeValue(/b/));
+  });
+
   it('renders arrays and objects without spaces (matching the error message format)', () => {
     expect(serializeValue([1, 'a'])).toBe("[1,'a']");
     expect(serializeValue({ a: 1, b: 'x' })).toBe("{a:1,b:'x'}");

--- a/src/lib/serialize-args.ts
+++ b/src/lib/serialize-args.ts
@@ -8,7 +8,7 @@
  * - single-quoted strings (`'a'`, with `\` and `'` escaped),
  * - bracketed arrays / braced objects without spaces,
  * - distinct renderings for the values `JSON.stringify` would mangle or throw on
- *   (`undefined`, `-0`, functions, symbols, `BigInt`, `Date`, `Map`, `Set`),
+ *   (`undefined`, `-0`, functions, symbols, `BigInt`, `Date`, `RegExp`, `Map`, `Set`),
  * - and circular-reference safety (so an object that references itself yields a
  *   stable key instead of overflowing the stack).
  *
@@ -76,6 +76,13 @@ function serializeMap(value: Map<unknown, unknown>, context: SerializeContext): 
 function serializeShape(value: object, context: SerializeContext): string {
   if (value instanceof Date) {
     return `new Date(${value.getTime()})`;
+  }
+
+  // A regular expression has no own enumerable entries, so the generic object branch renders every
+  // one of them as `{}` — `calledWith(/a/)` and `calledWith(/b/)` would share a key and the second
+  // config would silently answer the first one's calls. Its source and flags are the whole value.
+  if (value instanceof RegExp) {
+    return String(value);
   }
 
   if (value instanceof Map) {


### PR DESCRIPTION
Fixes #6.

Thanks to @floAtEbcont for the report — the reproduction in the issue was minimal and complete, and it pointed straight at the line that was wrong.

## What was broken

```ts
spy.test.calledWith(12, expect.anything()).mockReturnValue('success');
expect(spy.test(12, { y: 3 })).toEqual('success'); // ✅

spy.test.calledWith(12, expect.anything()).mockReturnValue('failure');
expect(spy.test(12, { y: 3 })).toEqual('failure'); // ❌ returned 'success'
```

The same argument list, re-registered, kept answering with the value it was given the first time. With literal arguments (`calledWith(12, { y: 3 })`) it worked; only a config holding an asymmetric matcher did not.

## Why

`calledWith` has two storage strategies. A literal argument list is serialized into a string key and kept in a map, so registering it again simply overwrites the entry — that is where the override came from for free. A list holding `expect.anything()` cannot be a static key, so it is kept as a predicate in a list, and lookup takes the **first** predicate that matches.

`expect.anything()` builds a fresh object on every call, so nothing recognised the second config as the same argument list. It was appended *behind* a config that still matched every call it was supposed to take over, and was therefore unreachable. A `beforeEach` that reconfigured the same spy also grew that list once per test.

## The fix

`ArgsMap.set` now looks for an equivalent asymmetric config and replaces it **in place**.

In place, rather than appended, because registration order is what decides between two *overlapping* configs, and an override must not quietly reorder them:

```ts
spy.load.calledWith(expect.any(Number)).mockReturnValue('number');
spy.load.calledWith(expect.anything()).mockReturnValue('anything');
spy.load.calledWith(expect.any(Number)).mockReturnValue('number again');

spy.load(7);   // 'number again' — the narrow config keeps its position
spy.load('x'); // 'anything'
```

Two matchers count as the same argument when they accept the same values: same matcher class (prototype identity), same own state (`sample`, `inverse`, `precision`), and both carrying the runner's `Symbol.for('jest.asymmetricMatcher')` brand. The class has to be compared as well as the state, because `expect.stringContaining('a')` and `expect.stringMatching('a')` differ in behaviour and not in fields.

A hand-rolled `{ asymmetricMatch }` object is deliberately excluded from that: it carries no brand, and its verdict lives in a closure that no comparison can read, so two of them are always two configs and only that very instance, re-registered, overrides. Guessing there would silently drop a config, which is a worse bug than the one being fixed.

This covers the whole chain — `mockReturnValue` / `returnValue`, `resolveWith`, `nextWith`, `nextOneTimeWith`, `nextWithValues`, the per-call variants — and `mustBeCalledWith` alike, since all of them register through the same map. The issue's note about `nextWith` and `nextOneTimeWith` is the same defect, and there is a test for it.

### One adjacent bug found on the way

A `RegExp` argument has no own enumerable entries, so the serializer rendered every one of them as `{}`: `calledWith(/a/)` answered a call made with `/b/`, and a `mustBeCalledWith` mismatch printed `{}` on both sides. It now renders as its literal (`/ab+/giu`). This is also what tells `stringMatching` apart from `stringContaining` above, so it is in this PR rather than a separate one.

## Tests

The reproduction from the issue is in the suite verbatim, both halves — the literal one that always worked is kept as the control (`src/auto-spy.spec.ts`):

- `overrides calledWith for exact arguments and for matcher arguments alike (issue #6)`
- `calledWith with an equivalent matcher overrides the earlier config` — plus the precedence guarantee above
- `calledWith().nextWith and .resolveWith are overridden through an equivalent matcher`

And 10 unit tests on `ArgsMap` itself (`src/lib/args-map.spec.ts`): a differing `sample` does not override, two matcher classes with identical state stay apart, a matcher and its `not` form stay apart, the literals around a matcher have to match too, arity, a matcher position versus a literal one, a hand-rolled matcher compared by reference, and the registration order being preserved across an override. `serialize-args.spec.ts` covers the `RegExp` rendering.

Verified the tests actually catch the defect: reverting the one-line change in `#setMatcherConfig` so it appends again fails 8 of them, the issue's reproduction included.

## Docs

`README.md`, `AGENTS.md`, the docs site (`core/control-helpers`) and the agent skill now state the matching order and that re-registering the same arguments overrides.

While checking the fix on the other runtimes, one gap turned out to be pre-existing and worth writing down: on **`bun:test`**, an asymmetric matcher inside `calledWith` never matches at all. Bun's `expect.any()` / `expect.objectContaining()` are native objects exposing no `asymmetricMatch` and no readable state, so the config is stored as an ordinary argument and the call falls through to `undefined`. That is not a regression and not fixed here — it would need matcher evaluation reimplemented for Bun — but it is now documented in `runtimes/bun.md` and in the skill instead of failing quietly.

## Checks

`npm run check` is green: typecheck, lint, jscpd, `llms:check`, the sync checks, **100 % coverage** over `src/lib/**` and `src/cli/**`, the type tests, and the shared-env, zone, Bun and Bun-Angular suites.
